### PR TITLE
Refactor tree rendering logic and add parent-aware mapping.

### DIFF
--- a/src/main/java/org/treefx/component/Node.java
+++ b/src/main/java/org/treefx/component/Node.java
@@ -28,9 +28,9 @@ public class Node extends VBox {
 
     public TreeCtxStrict<NodeInfo> getNodeCtx() { return nodeCtx; }
 
-    public Node(Maybe<Node> mNodeFather, Maybe<Line> mline, TreeCtxStrict<NodeInfo> nodeCtx, TreeEditor editor) {
+    public Node(Maybe<Node> mNodeFather, TreeCtxStrict<NodeInfo> nodeCtx, TreeEditor editor) {
         this.mNodeFather = mNodeFather;
-        this.mline = mline;
+        this.mline = new Maybe.Nothing<>();
         this.nodeCtx = nodeCtx;
         this.editor = editor;
 
@@ -50,6 +50,7 @@ public class Node extends VBox {
             case Maybe.Nothing() -> {}
             case Maybe.Just(Node nodeFather) ->
                 this.boundsInParentProperty().addListener((observable, oldValue, newValue) -> {
+                    System.out.println(newValue.getWidth());
                     Point2D fatherPoint = nodeFather.localToScene(nodeFather.getWidth() / 2, nodeFather.getHeight());
                     Point2D childPoint = this.localToScene( newValue.getWidth() / 2, 0);
                     this.updateLine(fatherPoint, childPoint);
@@ -123,6 +124,7 @@ public class Node extends VBox {
 
     public void renderNode(Point2D localCoords) {
         this.nodeCtx.getValue().setPos(localCoords);
+
         this.relocate(
                 (int) localCoords.getX() - (this.getBoundsInParent().getWidth() / 2),
                 (int) localCoords.getY() - (this.getBoundsInParent().getHeight() / 2)

--- a/src/main/java/org/treefx/model/ziplist/ZipListStrict.java
+++ b/src/main/java/org/treefx/model/ziplist/ZipListStrict.java
@@ -139,11 +139,14 @@ public class ZipListStrict<a> implements ZipList<a>{
     }
 
     public void mapM(Function<a, Void> k) {
+        if (size == 0) return;
+
         toStart();
         do {
             k.apply(this.mNode.fromJust().getCurrent());
         }
         while (this.next());
+        this.toStart();
     }
 
     @Override

--- a/src/main/java/org/treefx/model/ziptree/TreeCtxStrict.java
+++ b/src/main/java/org/treefx/model/ziptree/TreeCtxStrict.java
@@ -5,6 +5,7 @@ import org.treefx.model.ziplist.ZipListStrict;
 import org.treefx.utils.adt.Maybe;
 import org.treefx.utils.adt.T;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class TreeCtxStrict<a> {
@@ -42,7 +43,7 @@ public class TreeCtxStrict<a> {
     public void setChildren(ZipListStrict<T<a, TreeCtxStrict<a>>> children) { this.children = children; }
 
     public void downMap(Function<a, Void> k) {
-        var a = this.brothers.extract().fromJust().fst();
+        var a = this.current.getCurrent().fst();
         k.apply(a);
         this.children.mapM(x -> {
             x.snd().downMap(k);
@@ -50,4 +51,16 @@ public class TreeCtxStrict<a> {
         });
     }
 
+    public <b> void downMapWithFatherGO(Maybe<b> mfatherResult, BiFunction<Maybe<b>, TreeCtxStrict<a>, b> k) {
+        var a = this.current.getCurrent().snd();
+        var b = k.apply(mfatherResult, a);
+        this.children.mapM(x -> {
+            x.snd().downMapWithFatherGO(new Maybe.Just<>(b), k);
+            return null;
+        });
+    }
+
+    public <b> void downMapWithFather(BiFunction<Maybe<b>, TreeCtxStrict<a>, b> k) {
+        this.downMapWithFatherGO(new Maybe.Nothing<>(), k);
+    }
 }

--- a/src/main/java/org/treefx/model/ziptree/ZipTreeStrict.java
+++ b/src/main/java/org/treefx/model/ziptree/ZipTreeStrict.java
@@ -7,6 +7,7 @@ import org.treefx.utils.adt.T;
 
 import java.util.LinkedList;
 import java.util.Stack;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public class ZipTreeStrict<a> {
@@ -36,6 +37,8 @@ public class ZipTreeStrict<a> {
             }
         }
     }
+
+    public void toRoot() { this.ctx = this.root; }
 
     public int toChild(int ix) {
         var children = this.ctx.getChildren();
@@ -137,4 +140,6 @@ public class ZipTreeStrict<a> {
     }
 
     public void mapM(Function<a, Void> k) { this.root.downMap(k); }
+
+    public <b> void mapWithFatherM(BiFunction<Maybe<b>, TreeCtxStrict<a>, b> k) { this.root.downMapWithFather(k); }
 }

--- a/src/main/resources/org/treefx/component/Node.fxml
+++ b/src/main/resources/org/treefx/component/Node.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.VBox?>
 
-<fx:root fx:id="node_container" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" type="javafx.scene.layout.VBox" xmlns="http://javafx.com/javafx/21.0.3-internal" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root fx:id="node_container" alignment="TOP_CENTER" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" type="javafx.scene.layout.VBox" xmlns="http://javafx.com/javafx/21.0.3-internal" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <ImageView fx:id="node_img" fitHeight="108.0" fitWidth="192.0" pickOnBounds="true" preserveRatio="true">
          <viewport>


### PR DESCRIPTION
Refactored tree initialization to use parent-aware mapping, improving node rendering and positional accuracy. Introduced `mapWithFatherM` and `downMapWithFather` methods for hierarchical traversal with parent context. Removed redundant code and streamlined data flow, enhancing maintainability and reducing duplication.